### PR TITLE
Adds conditional ip fetch to refresh_metadata_async

### DIFF
--- a/lib/cassandra/cluster/control_connection.rb
+++ b/lib/cassandra/cluster/control_connection.rb
@@ -443,20 +443,6 @@ module Cassandra
 
           ips = ::Set.new
 
-          unless local.empty?
-            # Re-use the existing host information if the host is already
-            # registered. This allows custom port config to be maintained.
-            ip = if @registry.has_host?(connection.host)
-              @registry.host(connection.host).ip
-            else
-              IPAddr.new(connection.host)
-            end
-            ips << ip
-            data = local.first
-            @registry.host_found(ip, data)
-            @metadata.update(data)
-          end
-
           peers.shuffle!
           peers.each do |data|
             ip = peer_ip(data)
@@ -487,7 +473,14 @@ module Cassandra
           raise Errors::InternalError, "Unable to fetch connected host's metadata" if local.empty?
 
           data = local.first
-          @registry.host_found(IPAddr.new(connection.host), data)
+          # Re-use the existing host information if the host is already
+          # registered. This allows custom port config to be maintained.
+          ip = if @registry.has_host?(connection.host)
+            @registry.host(connection.host).ip
+          else
+            IPAddr.new(connection.host)
+          end
+          @registry.host_found(ip, data)
           @metadata.update(data)
 
           @logger.info("Completed refreshing connected host's metadata")


### PR DESCRIPTION
...so that port numbers get preserved.

Using binding.pry, I was able to prove that lib/cassandra/cluster/control_connection.rb's refresh_metadata_async method gets called when a cluster is created:

cluster = Cassandra.cluster(client_config)

I was able to prove that without this patch, after refresh_metadata_async is called, it's possible for a Backupify::Stunnel::IPAddrWithPort to become a regular IPAddr and therefore lose its port number (see branch 3.0.0.rc.1-port_support_refresh_metadata_async_plain to see what I mean).

Following through the code in backupify/ that creates CQL/Cass2 connections, this is the series of events:

datastore_config = Backupify::DatastoreConfig.new('cass_datastores').for_datastore('storage_metadata');
cluster_config = datastore_config[:cluster_config];
client_config = {
  :synchronize_schema => false,
};
client_config[:port] = cluster_config[:port] if cluster_config[:port];
if cluster_config[:address_resolution_policy]
  client_config[:address_resolution_policy] = cluster_config[:address_resolution_policy].constantize
end;
if cluster_config[:use_resolved_addresses]
  client_config[:hosts] = client_config[:address_resolution_policy].resolved_addresses
else
  client_config[:hosts] = cluster_config[:hosts]
end;
[:connections_per_local_node, :connections_per_remote_node].each do |opt_name|
  next unless value = cluster_config[opt_name]
  client_config[opt_name] = value
end;
if cluster_config.keys.include?(:idle_timeout.to_s)
  client_config[:idle_timeout] = cluster_config[:idle_timeout]
end;
load_balancing = Cassandra::LoadBalancing::Policies::WhiteList.new(client_config[:hosts].sample(3), Cassandra::LoadBalan
client_config[:load_balancing_policy] = load_balancing;
client_config[:consistency] = :quorum;
cluster = Cassandra.cluster(client_config); # <-- this is where refresh_metadata_async gets called
## Now, to see the list of ips in the registry, do this:

control_connection = cluster.instance_variable_get(:@control_connection);
registry = control_connection.instance_variable_get(:@registry);
## And, to prove that existing ips didn't get replaced with IPAddr, run this:

registry.hosts.each do |h|
  port = if h.ip.class == Backupify::Stunnel::IPAddrWithPort
    h.ip.port
  else
    0
  end
  puts "#{h.ip.class} #{h.ip.to_s}:#{port}"
end;

You will see this:

Backupify::Stunnel::IPAddrWithPort 127.0.0.81:27526
Backupify::Stunnel::IPAddrWithPort 127.0.0.58:27474
Backupify::Stunnel::IPAddrWithPort 127.0.0.67:27494
...

NOT this (unless branch 3.0.0.rc.1-port_support_refresh_metadata_async_plain):

Backupify::Stunnel::IPAddrWithPort 127.0.0.54:27468
Backupify::Stunnel::IPAddrWithPort 127.0.0.7:27538
IPAddr 127.0.0.67:0                                                       ## <--- oops!
Backupify::Stunnel::IPAddrWithPort 127.0.0.82:27528
Backupify::Stunnel::IPAddrWithPort 127.0.0.66:27492
