### PR TITLE
support for custom backupify datum type 

### DIFF
--- a/lib/cassandra.rb
+++ b/lib/cassandra.rb
@@ -834,7 +834,7 @@ require 'cassandra/timestamp_generator'
 require 'cassandra/util'
 
 # murmur3 hash extension
-require 'cassandra_murmur3'
+#require 'cassandra_murmur3'
 
 # SortedSet has a race condition where it does some class/global initialization when the first instance is created.
 # If this is done in a multi-threaded environment, bad things can happen. So force the initialization here,

--- a/lib/cassandra.rb
+++ b/lib/cassandra.rb
@@ -834,7 +834,7 @@ require 'cassandra/timestamp_generator'
 require 'cassandra/util'
 
 # murmur3 hash extension
-#require 'cassandra_murmur3'
+require 'cassandra_murmur3'
 
 # SortedSet has a race condition where it does some class/global initialization when the first instance is created.
 # If this is done in a multi-threaded environment, bad things can happen. So force the initialization here,

--- a/lib/cassandra/protocol/coder.rb
+++ b/lib/cassandra/protocol/coder.rb
@@ -404,6 +404,7 @@ module Cassandra
                                                  type.value_type)
         when :udt              then write_udt_v3(buffer, value, type.fields)
         when :tuple            then write_tuple_v3(buffer, value, type.members)
+        when :custom           then write_text(buffer, value)
         else
           raise Errors::EncodingError, %(Unsupported value type: #{type})
         end

--- a/lib/cassandra/protocol/coder.rb
+++ b/lib/cassandra/protocol/coder.rb
@@ -257,7 +257,7 @@ module Cassandra
         when :date             then read_date(buffer)
         when :custom
           if type.name == "com.backupify.db.DatumType"
-            return read_ascii(buffer)
+            return read_text(buffer)
           else
             read_custom(buffer, type, custom_type_handlers)
           end
@@ -507,7 +507,7 @@ module Cassandra
           Cassandra::Tuple::Strict.new(members, values)
         when :custom
           if type.name == "com.backupify.db.DatumType"
-            return read_ascii(buffer)
+            return read_text(buffer)
           else
             raise Errors::DecodingError, %(Unsupported value type: #{type})
           end
@@ -712,7 +712,7 @@ module Cassandra
           value
         when :custom
           if type.name == "com.backupify.db.DatumType"
-            return read_ascii(buffer)
+            return read_text(buffer)
           else
             raise Errors::DecodingError, %(Unsupported value type: #{type})
           end

--- a/lib/cassandra/protocol/coder.rb
+++ b/lib/cassandra/protocol/coder.rb
@@ -257,7 +257,7 @@ module Cassandra
         when :date             then read_date(buffer)
         when :custom
           if type.name == "com.backupify.db.DatumType"
-            return read_text(buffer)
+            return read_ascii(buffer)
           else
             read_custom(buffer, type, custom_type_handlers)
           end
@@ -507,7 +507,7 @@ module Cassandra
           Cassandra::Tuple::Strict.new(members, values)
         when :custom
           if type.name == "com.backupify.db.DatumType"
-            return read_text(buffer)
+            return read_ascii(buffer)
           else
             raise Errors::DecodingError, %(Unsupported value type: #{type})
           end
@@ -712,7 +712,7 @@ module Cassandra
           value
         when :custom
           if type.name == "com.backupify.db.DatumType"
-            return read_text(buffer)
+            return read_ascii(buffer)
           else
             raise Errors::DecodingError, %(Unsupported value type: #{type})
           end

--- a/lib/cassandra/protocol/coder.rb
+++ b/lib/cassandra/protocol/coder.rb
@@ -117,12 +117,7 @@ module Cassandra
                                                  type.value_type)
         when :udt              then write_udt_v4(buffer, value, type.fields)
         when :tuple            then write_tuple_v4(buffer, value, type.members)
-        when :custom
-          if type.name == "com.backupify.db.DatumType"
-            write_text(buffer, value)
-          else
-            raise Errors::EncodingError, %(Unsupported value type: #{type})
-          end
+        when :custom           then write_custom(buffer, value, type)
         else
           raise Errors::EncodingError, %(Unsupported value type: #{type})
         end
@@ -415,12 +410,7 @@ module Cassandra
                                                  type.value_type)
         when :udt              then write_udt_v3(buffer, value, type.fields)
         when :tuple            then write_tuple_v3(buffer, value, type.members)
-        when :custom
-          if type.name == "com.backupify.db.DatumType"
-            write_text(buffer, value)
-          else
-            raise Errors::EncodingError, %(Unsupported value type: #{type})
-          end
+        when :custom           then write_custom(buffer, value, type)
         else
           raise Errors::EncodingError, %(Unsupported value type: #{type})
         end
@@ -655,12 +645,7 @@ module Cassandra
                                                  value,
                                                  type.key_type,
                                                  type.value_type)
-        when :custom
-          if type.name == "com.backupify.db.DatumType"
-            write_text(buffer, value)
-          else
-            raise Errors::EncodingError, %(Unsupported value type: #{type})
-          end
+        when :custom           then write_custom(buffer, value, type)
         else
           raise Errors::EncodingError, %(Unsupported value type: #{type})
         end

--- a/lib/cassandra/protocol/coder.rb
+++ b/lib/cassandra/protocol/coder.rb
@@ -437,7 +437,6 @@ module Cassandra
         when :text             then read_text(buffer)
         when :varint           then read_varint(buffer)
         when :inet             then read_inet(buffer)
-        when :custom           then read_text(buffer)
         when :list
           return nil unless read_size(buffer)
 

--- a/lib/cassandra/protocol/coder.rb
+++ b/lib/cassandra/protocol/coder.rb
@@ -117,6 +117,12 @@ module Cassandra
                                                  type.value_type)
         when :udt              then write_udt_v4(buffer, value, type.fields)
         when :tuple            then write_tuple_v4(buffer, value, type.members)
+        when :custom
+          if type.name == "com.backupify.db.DatumType"
+            write_text(buffer, value)
+          else
+            raise Errors::EncodingError, %(Unsupported value type: #{type})
+          end
         else
           raise Errors::EncodingError, %(Unsupported value type: #{type})
         end
@@ -254,12 +260,12 @@ module Cassandra
         when :smallint         then read_smallint(buffer)
         when :time             then read_time(buffer)
         when :date             then read_date(buffer)
-        when :custom    
+        when :custom
           if type.name == "com.backupify.db.DatumType"
             return read_text(buffer)
           else
             read_custom(buffer, type, custom_type_handlers)
-          end       
+          end
         when :list
           return nil unless read_size(buffer)
 
@@ -409,7 +415,12 @@ module Cassandra
                                                  type.value_type)
         when :udt              then write_udt_v3(buffer, value, type.fields)
         when :tuple            then write_tuple_v3(buffer, value, type.members)
-        when :custom           then write_text(buffer, value)
+        when :custom
+          if type.name == "com.backupify.db.DatumType"
+            write_text(buffer, value)
+          else
+            raise Errors::EncodingError, %(Unsupported value type: #{type})
+          end
         else
           raise Errors::EncodingError, %(Unsupported value type: #{type})
         end
@@ -644,6 +655,12 @@ module Cassandra
                                                  value,
                                                  type.key_type,
                                                  type.value_type)
+        when :custom
+          if type.name == "com.backupify.db.DatumType"
+            write_text(buffer, value)
+          else
+            raise Errors::EncodingError, %(Unsupported value type: #{type})
+          end
         else
           raise Errors::EncodingError, %(Unsupported value type: #{type})
         end

--- a/lib/cassandra/protocol/coder.rb
+++ b/lib/cassandra/protocol/coder.rb
@@ -437,6 +437,7 @@ module Cassandra
         when :text             then read_text(buffer)
         when :varint           then read_varint(buffer)
         when :inet             then read_inet(buffer)
+        when :custom           then read_text(buffer)
         when :list
           return nil unless read_size(buffer)
 

--- a/lib/cassandra/protocol/coder.rb
+++ b/lib/cassandra/protocol/coder.rb
@@ -254,7 +254,12 @@ module Cassandra
         when :smallint         then read_smallint(buffer)
         when :time             then read_time(buffer)
         when :date             then read_date(buffer)
-        when :custom           then read_custom(buffer, type, custom_type_handlers)
+        when :custom    
+          if type.name == "com.backupify.db.DatumType"
+            return read_text(buffer)
+          else
+            read_custom(buffer, type, custom_type_handlers)
+          end       
         when :list
           return nil unless read_size(buffer)
 
@@ -498,6 +503,12 @@ module Cassandra
           values.fill(nil, values.length, (members.length - values.length))
 
           Cassandra::Tuple::Strict.new(members, values)
+        when :custom
+          if type.name == "com.backupify.db.DatumType"
+            return read_text(buffer)
+          else
+            raise Errors::DecodingError, %(Unsupported value type: #{type})
+          end
         else
           raise Errors::DecodingError, %(Unsupported value type: #{type})
         end
@@ -696,6 +707,12 @@ module Cassandra
           end
 
           value
+        when :custom
+          if type.name == "com.backupify.db.DatumType"
+            return read_text(buffer)
+          else
+            raise Errors::DecodingError, %(Unsupported value type: #{type})
+          end
         else
           raise Errors::DecodingError, %(Unsupported value type: #{type})
         end


### PR DESCRIPTION
The driver uses multiple protocol versions - four to be exact. The first three do not support custom types. We have extended the read and write portions of the code to support the datum type which is a custom type.